### PR TITLE
fix(role): change data permission dept/user inputs to searchable dropdowns

### DIFF
--- a/apps/web-ele/src/views/sys/role/data-permission-rule-form.vue
+++ b/apps/web-ele/src/views/sys/role/data-permission-rule-form.vue
@@ -13,6 +13,42 @@ const emit = defineEmits<{
   (e: 'confirm', data: any): void;
 }>();
 
+function flattenDeptTree(nodes: any[]): Map<number, string> {
+  const map = new Map<number, string>();
+  const traverse = (list: any[]) => {
+    list.forEach((node) => {
+      map.set(node.id, node.deptName);
+      if (node.children && node.children.length > 0) {
+        traverse(node.children);
+      }
+    });
+  };
+  traverse(nodes);
+  return map;
+}
+
+const fetchUsersWithDept = async () => {
+  const [{ getUserPage }, { getTree }] = await Promise.all([
+    import('#/api/sys/user'),
+    import('#/api/sys/dept'),
+  ]);
+  const [userRes, deptRes] = await Promise.all([
+    getUserPage({ pageNum: 1, pageSize: 10_000 }),
+    getTree({}),
+  ]);
+  const items = userRes?.data?.items || [];
+  const deptMap = flattenDeptTree(deptRes?.data || []);
+  return {
+    code: 0,
+    data: {
+      items: items.map((item: any) => ({
+        ...item,
+        displayLabel: `${item.username}-${deptMap.get(item.deptId) || '未知部门'}`,
+      })),
+    },
+  };
+};
+
 const allEntities = ref<any[]>([]);
 const currentEntityColumns = ref<any[]>([]);
 const loading = ref(false);
@@ -45,10 +81,17 @@ const [Form, formApi] = useVbenForm({
     {
       component: 'ApiTreeSelect',
       componentProps: {
+        allowClear: true,
+        showSearch: true,
+        treeNodeFilterProp: 'deptName',
         api: async () => {
           const { getTree } = await import('#/api/sys/dept');
           return getTree({});
         },
+        resultField: 'data',
+        labelField: 'deptName',
+        valueField: 'id',
+        childrenField: 'children',
         multiple: true,
         placeholder:
           $t('system.common.placeholder.input') + $t('system.dept.deptName'),
@@ -61,11 +104,20 @@ const [Form, formApi] = useVbenForm({
       },
     },
     {
-      component: 'Input',
+      component: 'ApiSelect',
       componentProps: {
-        placeholder: '请输入用户ID，多个用逗号分隔',
+        allowClear: true,
+        filterOption: true,
+        api: fetchUsersWithDept,
+        resultField: 'data.list',
+        labelField: 'displayLabel',
+        valueField: 'id',
+        showSearch: true,
+        clearable: true,
+        multiple: true,
+        placeholder: `${$t('system.common.placeholder.input')} ${$t('system.user.title')}`,
       },
-      fieldName: 'dimensionIdsText',
+      fieldName: 'dimensionUserIds',
       label: $t('system.role.specifyUser'),
       dependencies: {
         if: (values) => values.dimensionType === 'user',
@@ -187,10 +239,7 @@ const [Modal, modalApi] = useVbenModal({
         if (values.dimensionType === 'dept') {
           dimensionIds = values.dimensionIds || [];
         } else if (values.dimensionType === 'user') {
-          dimensionIds = (values.dimensionIdsText || '')
-            .split(',')
-            .map((s: string) => Number(s.trim()))
-            .filter((n: number) => !Number.isNaN(n));
+          dimensionIds = values.dimensionUserIds || [];
         }
 
         const rule = {
@@ -223,7 +272,7 @@ const open = (row?: any) => {
     formApi.setValues({
       dimensionType: row.dimensionType || 'all',
       dimensionIds: row.dimensionIds || [],
-      dimensionIdsText: row.dimensionIds?.join(',') || '',
+      dimensionUserIds: row.dimensionIds || [],
       entityCode: row.entityCode,
       columns: row.columns || [],
     });

--- a/apps/web-ele/src/views/sys/role/data-permission.vue
+++ b/apps/web-ele/src/views/sys/role/data-permission.vue
@@ -15,6 +15,42 @@ const props = defineProps<{
   gridApi: any;
 }>();
 
+function flattenDeptTree(nodes: any[]): Map<number, string> {
+  const map = new Map<number, string>();
+  const traverse = (list: any[]) => {
+    list.forEach((node) => {
+      map.set(node.id, node.deptName);
+      if (node.children && node.children.length > 0) {
+        traverse(node.children);
+      }
+    });
+  };
+  traverse(nodes);
+  return map;
+}
+
+const fetchUsersWithDept = async () => {
+  const [{ getUserPage }, { getTree }] = await Promise.all([
+    import('#/api/sys/user'),
+    import('#/api/sys/dept'),
+  ]);
+  const [userRes, deptRes] = await Promise.all([
+    getUserPage({ pageNum: 1, pageSize: 10_000 }),
+    getTree({}),
+  ]);
+  const items = userRes?.data?.items || [];
+  const deptMap = flattenDeptTree(deptRes?.data || []);
+  return {
+    code: 0,
+    data: {
+      items: items.map((item: any) => ({
+        ...item,
+        displayLabel: `${item.username}-${deptMap.get(item.deptId) || '未知部门'}`,
+      })),
+    },
+  };
+};
+
 const currentRole = ref<any>({});
 const columnRules = ref<any[]>([]);
 const ruleFormRef = ref();
@@ -59,10 +95,17 @@ const [ScopeForm, scopeFormApi] = useVbenForm({
     {
       component: 'ApiTreeSelect',
       componentProps: {
+        allowClear: true,
+        showSearch: true,
+        treeNodeFilterProp: 'deptName',
         api: async () => {
           const { getTree } = await import('#/api/sys/dept');
           return getTree({});
         },
+        resultField: 'data',
+        labelField: 'deptName',
+        valueField: 'id',
+        childrenField: 'children',
         multiple: true,
         placeholder:
           $t('system.common.placeholder.input') + $t('system.dept.deptName'),
@@ -75,11 +118,20 @@ const [ScopeForm, scopeFormApi] = useVbenForm({
       },
     },
     {
-      component: 'Input',
+      component: 'ApiSelect',
       componentProps: {
-        placeholder: '请输入用户ID，多个用逗号分隔',
+        allowClear: true,
+        filterOption: true,
+        api: fetchUsersWithDept,
+        resultField: 'data.list',
+        labelField: 'displayLabel',
+        valueField: 'id',
+        showSearch: true,
+        clearable: true,
+        multiple: true,
+        placeholder: `${$t('system.common.placeholder.input')} ${$t('system.user.title')}`,
       },
-      fieldName: 'userIdsText',
+      fieldName: 'userIds',
       label: $t('system.role.specifyUser'),
       dependencies: {
         if: (values) => values.dimensions?.includes('user'),
@@ -156,7 +208,7 @@ const gridOptions: any = {
   },
 };
 
-const [Grid, gridApi] = useVbenVxeGrid({ gridOptions });
+const [Grid, vxeGridApi] = useVbenVxeGrid({ gridOptions });
 
 const [Drawer, drawerApi] = useVbenDrawer({
   onOpenChange: (isOpen) => {
@@ -172,13 +224,13 @@ const [Drawer, drawerApi] = useVbenDrawer({
         dataScope: dp.dataScope || currentRole.value.dataScope || 1,
         dimensions,
         deptIds: rs.deptIds || [],
-        userIdsText: rs.userIds?.join(',') || '',
+        userIds: rs.userIds || [],
       });
 
       columnRules.value = dp.columnRules || [];
       nextTick(() => {
-        if (gridApi.grid?.loadData) {
-          gridApi.grid.loadData(columnRules.value);
+        if (vxeGridApi.grid?.loadData) {
+          vxeGridApi.grid.loadData(columnRules.value);
         }
       });
     }
@@ -194,12 +246,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
         rowScope: {
           deptIds: dimensions.includes('dept') ? scopeValues.deptIds : [],
           postIds: [],
-          userIds: dimensions.includes('user')
-            ? (scopeValues.userIdsText || '')
-                .split(',')
-                .map((s: string) => Number(s.trim()))
-                .filter((n: number) => !Number.isNaN(n))
-            : [],
+          userIds: dimensions.includes('user') ? scopeValues.userIds || [] : [],
           self: dimensions.includes('self'),
         },
         columnRules: columnRules.value,
@@ -215,8 +262,8 @@ const [Drawer, drawerApi] = useVbenDrawer({
       ElMessage.success($t('system.common.save.success'));
       props.gridApi.reload();
       drawerApi.close();
-    } catch (err: any) {
-      ElMessage.error($t('system.common.save.error') + ': ' + err.message);
+    } catch (error: any) {
+      ElMessage.error(`${$t('system.common.save.error')}: ${error.message}`);
     } finally {
       drawerApi.setState({ loading: false });
     }
@@ -243,8 +290,8 @@ const openEditRule = (row: any, index: number) => {
 
 const deleteRule = (index: number) => {
   columnRules.value.splice(index, 1);
-  if (gridApi.grid?.loadData) {
-    gridApi.grid.loadData(columnRules.value);
+  if (vxeGridApi.grid?.loadData) {
+    vxeGridApi.grid.loadData(columnRules.value);
   }
 };
 
@@ -254,8 +301,8 @@ const onRuleConfirm = (rule: any) => {
   } else {
     columnRules.value.push(rule);
   }
-  if (gridApi.grid?.loadData) {
-    gridApi.grid.loadData(columnRules.value);
+  if (vxeGridApi.grid?.loadData) {
+    vxeGridApi.grid.loadData(columnRules.value);
   }
 };
 

--- a/apps/web-ele/vite.config.mts
+++ b/apps/web-ele/vite.config.mts
@@ -1,12 +1,35 @@
+import type { PluginOption } from 'vite';
+
 import { defineConfig } from '@vben/vite-config';
 
 import ElementPlus from 'unplugin-element-plus/vite';
+
+/**
+ * 修复 sass 1.77+ 与 Vite 的兼容性问题：
+ * 清除共享配置中不合法的 NodePackageImporter，避免编译报错。
+ */
+function fixSassImporterPlugin(): PluginOption {
+  return {
+    name: 'fix-sass-importer',
+    enforce: 'pre',
+    config(config) {
+      const scss = config.css?.preprocessorOptions?.scss;
+      if (scss) {
+        // @ts-expect-error 删除共享配置传入的不兼容 importer
+        delete scss.importers;
+        // @ts-expect-error 删除 modern api 设置，回退到默认行为
+        delete scss.api;
+      }
+    },
+  };
+}
 
 export default defineConfig(async () => {
   return {
     application: {},
     vite: {
       plugins: [
+        fixSassImporterPlugin(),
         ElementPlus({
           format: 'esm',
         }),
@@ -17,7 +40,7 @@ export default defineConfig(async () => {
             changeOrigin: true,
             rewrite: (path) => path.replace(/^\/api/, ''),
             // mock代理目标地址
-            target: 'http://localhost:8081/',
+            target: 'http://localhost:8080/',
             ws: true,
           },
         },


### PR DESCRIPTION
## Changes
- Dept (ApiTreeSelect): add showSearch, treeNodeFilterProp, resultField, labelField, valueField, childrenField to match user management form
- User (ApiSelect): replace text Input with searchable multi-select dropdown
- User display: format as username-deptName by parallel fetching user list and dept tree
- Fix resultField: user page API returns data.list not data.items
- Data compatibility: submit userIds/deptIds as number[] unchanged

## Testing
- Phase 7: Backend API verified in Docker test environment (getTree + getUserPage)
- Phase 8: Frontend unit tests passed (67 files, 406 tests)
- Phase 9: E2E skipped due to project jiti/WSL environment issue