### PR TITLE
fix and feat: gen table preview scroll and directory compression

### DIFF
--- a/apps/web-ele/src/views/gen/table/preview.vue
+++ b/apps/web-ele/src/views/gen/table/preview.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { TreeNodeData } from 'element-plus';
 
-import { reactive, ref } from 'vue';
+import { computed, reactive, ref } from 'vue';
 
 import { ColPage, useVbenForm, useVbenModal } from '@vben/common-ui';
 import { $t } from '@vben/locales';
@@ -12,6 +12,60 @@ import { codeDownload } from '#/api/gen/table';
 
 const writeForm = ref();
 const rightLabel = ref();
+
+interface PreviewTreeNode {
+  label: string;
+  value: string;
+  children?: PreviewTreeNode[];
+}
+
+/**
+ * 压缩单 child 目录链，类似 IDEA 的 Compact Empty Middle Packages
+ */
+function compressTreeNodes(nodes: PreviewTreeNode[]): PreviewTreeNode[] {
+  return nodes.map((node) => {
+    const compressed = compressNode(node);
+    return {
+      ...compressed,
+      children: compressed.children
+        ? compressTreeNodes(compressed.children)
+        : undefined,
+    };
+  });
+}
+
+function compressNode(node: PreviewTreeNode): PreviewTreeNode {
+  // 叶子节点（文件）或空目录，不压缩
+  if (!node.children || node.children.length === 0) {
+    return node;
+  }
+
+  // 多个子节点，不压缩
+  if (node.children.length !== 1) {
+    return node;
+  }
+
+  const [onlyChild] = node.children;
+
+  if (!onlyChild) {
+    return node;
+  }
+
+  // 唯一子节点也是目录，才压缩；如果是文件，保留当前目录层级
+  if (onlyChild.children && onlyChild.children.length > 0) {
+    return compressNode({
+      label: `${node.label}.${onlyChild.label}`,
+      value: onlyChild.value,
+      children: onlyChild.children,
+    });
+  }
+
+  return node;
+}
+
+const treeData = computed<PreviewTreeNode[]>(() =>
+  compressTreeNodes(writeForm.value || []),
+);
 
 const props = reactive({
   leftCollapsedWidth: 5,
@@ -92,7 +146,7 @@ defineExpose({ open, close });
         <div class="flex h-full flex-col overflow-hidden">
           <div class="flex-1 overflow-auto">
             <ElTree
-              :data="writeForm"
+              :data="treeData"
               :props="defaultProps"
               :expand-on-click-node="true"
               accordion

--- a/apps/web-ele/src/views/gen/table/preview.vue
+++ b/apps/web-ele/src/views/gen/table/preview.vue
@@ -76,7 +76,7 @@ defineExpose({ open, close });
 
 <template>
   <Modal
-    class="w-[100%] gen-preview-modal"
+    class="gen-preview-modal w-[100%]"
     :title="$t('codegen.table.form')"
     :destroy-on-close="true"
     :fullscreen="true"
@@ -110,7 +110,7 @@ defineExpose({ open, close });
         body-class="flex-1 overflow-auto p-4"
       >
         <div class="font-mono text-sm">
-          <pre class="whitespace-pre-wrap">{{ rightLabel }}</pre>
+          <pre class="m-0 whitespace-pre-wrap">{{ rightLabel }}</pre>
         </div>
       </ElCard>
     </ColPage>
@@ -118,14 +118,19 @@ defineExpose({ open, close });
 </template>
 
 <style>
-/* 让 Page 根元素在 Modal 中占满可用高度，从而使左右面板都能垂直铺满 */
 .gen-preview-modal .relative.min-h-40 {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 .gen-preview-modal .relative.min-h-40 > .relative {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+.gen-preview-modal .relative.min-h-40 > .relative > .h-full.p-4 {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
## Changes\n\n- fix(ui): gen table preview scroll behavior\n  - Fix internal scroll for long code preview\n  - Prevent outer Modal/body scrolling\n\n- feat(ui): compress single-child directory chains in preview tree\n  - Compress empty middle packages like IntelliJ IDEA\n  - e.g. com/ddd/test/ -> com.ddd.test/\n