### PR TITLE
feat(gen): prefill database name in table management search

### DIFF
--- a/apps/web-ele/src/views/gen/table/index.vue
+++ b/apps/web-ele/src/views/gen/table/index.vue
@@ -52,7 +52,6 @@ const formOptions: VbenFormProps = {
       fieldName: 'databaseName',
       label: $t('codegen.info.databaseName'),
       labelWidth: 120,
-      rules: 'required',
     },
     {
       component: 'Input',
@@ -103,11 +102,17 @@ const gridOptions: VxeTableGridOptions<RowType> = {
   proxyConfig: {
     ajax: {
       query: async ({ page }, formValues) => {
-        return await getTablePage({
+        const resp: any = await getTablePage({
           pageNum: page.currentPage,
           pageSize: page.pageSize,
           ...formValues,
         });
+        if (resp?.databaseName && !formValues?.databaseName) {
+          await gridApi.formApi.setValues({
+            databaseName: resp.databaseName,
+          });
+        }
+        return resp;
       },
     },
   },


### PR DESCRIPTION
Use databaseName returned from /gen/table/index page response to fill the Table Management search form when it is empty.