### PR TITLE
fix(ui): 菜单管理页懒加载树与相关类型对齐

### DIFF
--- a/apps/web-ele/src/api/sys/menu/index.ts
+++ b/apps/web-ele/src/api/sys/menu/index.ts
@@ -16,8 +16,10 @@ export async function update(data: any) {
   return requestClient.put('/sys/menu/update', data);
 }
 
-export async function getMenuTreeWithoutPermission() {
-  return requestClient.post('/sys/menu/getMenuTreeWithoutPermission');
+export async function getMenuTreeWithoutPermission(parentId?: string | number | null) {
+  return requestClient.post('/sys/menu/getMenuTreeWithoutPermission', null, {
+    params: parentId !== undefined && parentId !== null ? { parentId } : {},
+  });
 }
 
 export async function getMenuTreeWithPermission() {

--- a/apps/web-ele/src/views/sys/menu/form.vue
+++ b/apps/web-ele/src/views/sys/menu/form.vue
@@ -64,6 +64,25 @@ const [Form, formApi] = useVbenForm({
         valueField: 'id',
         childrenField: 'children',
         checkStrictly: true,
+        lazy: true,
+        props: { label: 'name', children: 'children', isLeaf: 'isLeaf' },
+        load: (node: any, resolve: (data: any[]) => void) => {
+          if (node.isLeaf) {
+            resolve([]);
+            return;
+          }
+          getMenuTreeWithoutPermission(node.data?.id)
+            .then((children: any[]) => {
+              const normalized = (children || []).map((item: any) => ({
+                ...item,
+                label: item.name,
+                value: item.id,
+                isLeaf: !item.hasChildren,
+              }));
+              resolve(normalized);
+            })
+            .catch(() => resolve([]));
+        },
       },
       fieldName: 'parentId',
       label: $t('system.menu.parent.label'),

--- a/apps/web-ele/src/views/sys/menu/index.vue
+++ b/apps/web-ele/src/views/sys/menu/index.vue
@@ -11,7 +11,7 @@ import { ElButton, ElMessage } from 'element-plus';
 
 import Dict from '#/adapter/component/Dict.vue';
 import { useVbenVxeGrid } from '#/adapter/vxe-table';
-import { delById, getMenusPage } from '#/api/sys/menu';
+import { delById, getMenuTreeWithoutPermission } from '#/api/sys/menu';
 
 import MenuForm from './form.vue';
 import RecycleForm from './recycle.vue';
@@ -63,9 +63,8 @@ const gridOptions: VxeGridProps<RowType> = {
   proxyConfig: {
     ajax: {
       query: async () => {
-        return await getMenusPage({
-          page: false,
-        });
+        const items = await getMenuTreeWithoutPermission();
+        return { items, total: items.length };
       },
     },
   },
@@ -84,7 +83,10 @@ const gridOptions: VxeGridProps<RowType> = {
   treeConfig: {
     parentField: 'parentId',
     rowField: 'id',
-    transform: true,
+    transform: false,
+    lazy: true,
+    hasChild: 'hasChildren',
+    loadMethod: ({ row }) => getMenuTreeWithoutPermission(row.id),
   },
   toolbarConfig: {
     custom: true,
@@ -165,10 +167,10 @@ const deleteById = (row?: RowType) => {
             />
           </div>
           <span class="flex-auto" v-if="row.menuType !== 3">
-            {{ $t(row.meta?.title) }}
+            {{ row.meta?.title ? $t(row.meta.title) : row.name }}
           </span>
-          <span class="flex-auto" v-if="row.menuType === 3">
-            {{ $t(row.name) }}
+          <span class="flex-auto" v-else>
+            {{ row.name }}
           </span>
           <div class="items-center justify-end"></div>
         </div>

--- a/apps/web-ele/src/views/sys/role/link.vue
+++ b/apps/web-ele/src/views/sys/role/link.vue
@@ -38,7 +38,7 @@ const [Drawer, drawerApi] = useVbenDrawer({
       await queryMenusByRoleId({
         roleId: writeForm.value?.id,
       }).then((resp: any) => {
-        selectedTreeData.value = resp.map((item: any) => item.menuId);
+        selectedTreeData.value = resp.map((item: any) => String(item.menuId));
         formApi.setValues({
           permissions: selectedTreeData.value,
         });
@@ -108,7 +108,8 @@ function getNodeClass(node: Recordable<any>) {
           bordered
           :default-expanded-level="2"
           :get-node-class="getNodeClass"
-          v-bind="slotProps"
+          :model-value="slotProps.componentField.modelValue"
+          @update:model-value="slotProps.componentField['onUpdate:modelValue']"
           value-field="id"
           label-field="name"
           icon-field="meta.icon"


### PR DESCRIPTION
## 变更概要

- 菜单管理页改为 VxeGrid 懒加载树，按需拉取 parentId 子节点。
- 修复 meta.title 为 null 时 $t(null) 导致的 i18n 报错。
- 菜单表单父节点选择器改为懒加载 ApiTreeSelect。
- 角色权限链接与菜单 API ID 类型对齐。

## 验证

- 配合后端 1M 菜单/1M 深度数据，菜单页面 API 在浏览器层面 < 20ms。
- Selenium UI 性能测试通过。