### PR TITLE
fix: remove unused _slotProps in role link drawer

### DIFF
--- a/apps/web-ele/src/views/sys/role/link.vue
+++ b/apps/web-ele/src/views/sys/role/link.vue
@@ -145,7 +145,7 @@ function onDataScopeChange(menuId: number, value: number) {
 <template>
   <Drawer class="w-[45%]" :title="$t('system.common.alert.permissions')">
     <Form>
-      <template #permissions="_slotProps">
+      <template #permissions>
         <VbenTree
           :tree-data="treeData"
           multiple


### PR DESCRIPTION
修复 role link drawer 中未使用的 _slotProps 变量，消除 ESLint 错误。